### PR TITLE
Save/Load screenshots instead of a11ytest files, include UIA metadata

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Enums/FileFilters.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/FileFilters.cs
@@ -12,6 +12,7 @@ namespace AccessibilityInsights.SharedUx.Enums
         public const string EventsFileFilter = "AccessibiltyInsights Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*";
         public const string TestExtension = ".a11ytest";
         public const string EventsExtension = ".a11yevent";
+        public const string ScreenshotFileFilter = "Image files (*.png)|*.png|All files (*.*)|*.*";
     }
 
     /// <summary>

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -83,6 +83,9 @@
     <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
+    <Reference Include="MetadataExtractor.StrongName, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b66b5ccaf776c301, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetadataExtractor.StrongName.2.1.0\lib\net45\MetadataExtractor.StrongName.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -110,14 +113,20 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="XmpCore.StrongName, Version=5.1.3.0, Culture=neutral, PublicKeyToken=961f4f366277b80e, processorArchitecture=MSIL">
+      <HintPath>..\packages\XmpCore.StrongName.5.1.3\lib\net35\XmpCore.StrongName.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
     <Compile Include="Enums\CCAView.cs" />
+    <Compile Include="Misc\AccessibleXmp.cs" />
     <Compile Include="Misc\CommandLineSettings.cs" />
     <Compile Include="Misc\CommandOptions.cs" />
+    <Compile Include="Misc\AccessibleScreenshot.cs" />
+    <Compile Include="Misc\ElementNode.cs" />
     <Compile Include="Misc\TelemetryEventFactory.cs" />
     <Compile Include="Modes\DialogContainerModeControl.xaml.cs">
       <DependentUpon>DialogContainerModeControl.xaml</DependentUpon>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -866,7 +866,7 @@ namespace AccessibilityInsights
                 var dlg = new System.Windows.Forms.OpenFileDialog
                 {
                     Title = Properties.Resources.btnLoad_ClickDialogTitle,
-                    Filter = FileFilters.A11yFileFilter,
+                    Filter = FileFilters.ScreenshotFileFilter,
                     InitialDirectory = ConfigurationManager.GetDefaultInstance().AppConfig.TestReportPath,
                     AutoUpgradeEnabled = !SystemParameters.HighContrast,
                 };

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -346,6 +346,14 @@ namespace AccessibilityInsights
             UpdateMainWindowUI();
         }
 
+        internal void HandleLoadingScreenshotData(string path, int? selectedElementId = null)
+        {
+            HandlePauseButtonToggle(true);
+
+            StartLoadingScreenshot(path);
+            UpdateMainWindowUI();
+        }
+
         /// <summary>
         /// Handle Load snapshot data and Request Ux Change
         /// </summary>
@@ -368,7 +376,7 @@ namespace AccessibilityInsights
         private bool TryOpenFile(string fileName, int? selectedElementId = null)
         {
             // array of file handlers to be attempted in order. If one throws an exception, the next will be tried
-            FileLoadHandler[] fileHandlers = { HandleLoadingSnapshotData, HandleLoadingEventData };
+            FileLoadHandler[] fileHandlers = { HandleLoadingScreenshotData, HandleLoadingSnapshotData, HandleLoadingEventData };
 
             foreach(var fileHandler in fileHandlers)
             {

--- a/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
@@ -187,6 +187,27 @@ namespace AccessibilityInsights
             UpdateMainCommandButtons();
         }
 
+        private void StartLoadingScreenshot(string path)
+        {
+            if (!path.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("path is not png");
+            }
+
+            var metadata = AccessibleScreenshot.LoadMetadata(path);
+
+            DisableElementSelector();
+
+            this.ctrlCurMode.HideControl();
+            this.ctrlCurMode = this.ctrlSnapMode;
+            /*
+            this.ctrlSnapMode.DataContextMode = GetDataContextModeForTest();
+            this.CurrentPage = AppPage.Test;
+            this.CurrentView = TestView.ElementDetails;
+            this.ctrlCurMode.ShowControl();
+            */
+        }
+
         /// <summary>
         /// Start snapshot mode with loading data
         /// </summary>

--- a/src/AccessibilityInsights/Misc/AccessibleScreenshot.cs
+++ b/src/AccessibilityInsights/Misc/AccessibleScreenshot.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Actions;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using MetadataExtractor;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace AccessibilityInsights.Misc
+{
+    /// <summary>
+    /// Action for saving snapshot data
+    /// </summary>
+    public static class AccessibleScreenshot
+    {
+        const string AccessibleKeyword = "a11ytree";
+
+        /// <summary>
+        /// Save snapshot zip
+        /// </summary>
+        /// <param name="ecId">ElementContext Id</param>
+        /// <param name="path">The output file</param>
+        public static void SaveScreenshot(string path, Guid ecId)
+        {
+            var a11yElement = DataManager.GetDefaultInstance().GetA11yElement(ecId, 0);
+            var bm = DataManager.GetDefaultInstance().GetScreenshot(ecId);
+
+            var trimmedElement = FromA11yElement(a11yElement);
+            var encoded = AddMetadata(bm, trimmedElement);
+            using (FileStream str = File.Open(path, FileMode.Create))
+            {
+                encoded.Save(str);
+            }
+        }
+
+        static ElementNode FromA11yElement(IA11yElement element)
+        {
+            var controlType = string.IsNullOrEmpty(element.LocalizedControlType) ?
+                ControlType.GetInstance().GetNameById(element.ControlTypeId) : element.LocalizedControlType;
+            return new ElementNode()
+            {
+                Name = element.Name,
+                ControlType = controlType,
+                Children = element.Children.Select(child => FromA11yElement(child))
+            };
+        }
+
+        public static BitmapSource Convert(System.Drawing.Bitmap bitmap)
+        {
+            var bitmapData = bitmap.LockBits(
+                new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                System.Drawing.Imaging.ImageLockMode.ReadOnly, bitmap.PixelFormat);
+
+            var bitmapSource = BitmapSource.Create(
+                bitmapData.Width, bitmapData.Height,
+                bitmap.HorizontalResolution, bitmap.VerticalResolution,
+                PixelFormats.Bgra32, null,
+                bitmapData.Scan0, bitmapData.Stride * bitmapData.Height, bitmapData.Stride);
+
+            bitmap.UnlockBits(bitmapData);
+            return bitmapSource;
+        }
+
+        public static PngBitmapEncoder AddMetadata(Bitmap bitmap, ElementNode element)
+        {
+            var tree = AccessibleXmp.ToXmpString(element);
+            var pngMetadata = new BitmapMetadata("png");
+
+            pngMetadata.SetQuery("/iTXt/Keyword", AccessibleKeyword.ToCharArray());
+            pngMetadata.SetQuery("/iTXt/TextEntry", tree);
+
+            //pngMetadata.SetQuery("/[1]iTXt/Keyword", "keyword0".ToCharArray());
+            //pngMetadata.SetQuery("/[1]iTXt/TextEntry", "textentry0");
+
+            var bmSource = Convert(bitmap);
+
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(bmSource, null, pngMetadata, null));
+            return encoder;
+        }
+
+        public static ElementNode LoadMetadata(string path)
+        {
+            var bitmap = new Bitmap(path).Clone();
+            IEnumerable<MetadataExtractor.Directory> directories = ImageMetadataReader.ReadMetadata(path);
+            var a11yTag = directories.Where(dir => dir.Name == "PNG-iTXt").SelectMany(dir => dir.Tags)
+                .Where(tag => tag.Description.StartsWith(AccessibleKeyword, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault();
+
+            if (a11yTag == null) return null;
+
+            return AccessibleXmp.FromXmpElement(a11yTag.Description.Substring(AccessibleKeyword.Length + 1));
+        }
+    }
+}

--- a/src/AccessibilityInsights/Misc/AccessibleXmp.cs
+++ b/src/AccessibilityInsights/Misc/AccessibleXmp.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace AccessibilityInsights.Misc
+{
+    class AccessibleXmp
+    {
+        public static string ToXmpString(ElementNode element)
+        {
+            // temporarily just use json
+            var json = JsonConvert.SerializeObject(element);
+            return json;
+        }
+
+        public static ElementNode FromXmpElement(string xmp)
+        {
+            return JsonConvert.DeserializeObject<ElementNode>(xmp);
+        }
+    }
+}

--- a/src/AccessibilityInsights/Misc/ElementNode.cs
+++ b/src/AccessibilityInsights/Misc/ElementNode.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AccessibilityInsights.Misc
+{
+    public class ElementNode
+    {
+        public string Name { get; set; }
+        public string ControlType { get; set; } // Localized, or fallback to control type
+        public IEnumerable<ElementNode> Children { get; set; }
+    }
+}

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Enums;
+using AccessibilityInsights.Misc;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Highlighting;
@@ -473,20 +474,19 @@ namespace AccessibilityInsights.Modes
         {
             var dlg = new System.Windows.Forms.SaveFileDialog
             {
-                Filter = FileFilters.TestFileFilter,
+                Filter = FileFilters.ScreenshotFileFilter,
                 InitialDirectory = Configuration.TestReportPath,
                 AutoUpgradeEnabled = !SystemParameters.HighContrast,
             };
 
-            dlg.FileName = dlg.InitialDirectory.GetSuggestedFileName(FileType.TestResults);
-
-            Logger.PublishTelemetryEvent(TelemetryAction.Hierarchy_Save);
+            dlg.FileName = "test.png";
 
             if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 try
                 {
-                    SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, this.ctrlHierarchy.GetSelectedElement().UniqueId, A11yFileMode.Inspect);
+                    AccessibleScreenshot.SaveScreenshot(dlg.FileName, this.ElementContext.Id);
+                    //SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, this.ctrlHierarchy.GetSelectedElement().UniqueId, A11yFileMode.Inspect);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Enums;
+using AccessibilityInsights.Misc;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Highlighting;
@@ -377,23 +378,25 @@ namespace AccessibilityInsights.Modes
         {
             var dlg = new System.Windows.Forms.SaveFileDialog
             {
-                Filter = FileFilters.TestFileFilter,
+                Filter = FileFilters.ScreenshotFileFilter,
                 InitialDirectory = Configuration.TestReportPath,
                 AutoUpgradeEnabled = !SystemParameters.HighContrast,
             };
 
-            dlg.FileName = dlg.InitialDirectory.GetSuggestedFileName(FileType.TestResults);
+            dlg.FileName = "test.png";
 
             if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 try
                 {
-                    SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, null, A11yFileMode.Test);
+                    AccessibleScreenshot.SaveScreenshot(dlg.FileName, this.ElementContext.Id);
+                    //SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, this.ctrlHierarchy.GetSelectedElement().UniqueId, A11yFileMode.Inspect);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
                 {
-                    MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.SaveException + " " + ex.Message));
+                    ex.ReportException();
+                    MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.SaveException, ex.Message));
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }

--- a/src/AccessibilityInsights/packages.config
+++ b/src/AccessibilityInsights/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net471" />
   <package id="CommandLineParser" version="2.5.0" targetFramework="net471" />
+  <package id="MetadataExtractor.StrongName" version="2.1.0" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.2" targetFramework="net471" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
@@ -14,4 +15,5 @@
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />
   <package id="WiX" version="3.11.1" targetFramework="net471" />
+  <package id="XmpCore.StrongName" version="5.1.3" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
- replace existing a11ytest file behavior with screenshots
- embed some UIA tree data in the png itself
- using JSON instead of XMP for the metadata format